### PR TITLE
Improved periodic messages feature

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -34,8 +34,23 @@ def get_direct_tf_id():
 def get_periodic_messages():
     return settings['bot_setup']['scheduled_messages']['message']
 
+def add_periodic_message(msg):
+    if not get_periodic_messages():
+        settings['bot_setup']['scheduled_messages'].update({'message': msg})
+    elif isinstance(get_periodic_messages(), str):
+        m = get_periodic_messages()
+        settings['bot_setup']['scheduled_messages'].update({'message': [m , msg]})
+    else:
+        settings['bot_setup']['scheduled_messages']['message'].append(msg)
+
 def get_periodic_timer():
+    if not settings['bot_setup']['scheduled_messages']['message_interval_minutes']:
+        settings['bot_setup']['scheduled_messages'].update({'message_interval_minutes' : 15})
     return settings['bot_setup']['scheduled_messages']['message_interval_minutes']
+
+
+def set_periodic_timer(time):
+    settings['bot_setup']['scheduled_messages']['message_interval_minutes'] = time
 
 def basics_enabled():
     enable = False


### PR DESCRIPTION
User can now add periodic messages and adjust the message interval while the bot is active.
Periodic message interval now defaults to 15 minutes if no value is provided in settings file. If there are no periodic messages configured in the settings file, the bot will check for added messages on the periodic message interval.