### PR TITLE
Added Try block around API call

### DIFF
--- a/util.py
+++ b/util.py
@@ -46,8 +46,12 @@ def getGameName(ctx, c_id, c_secret, channel):
     """
     client = TwitchHelix(client_id = c_id, client_secret = c_secret)
     client.get_oauth()
-    stream = client.get_streams(user_logins = channel)._queue[0]
-    game_id = stream["game_id"]
-    game_info = client.get_games(game_ids=game_id)
-    game_name = game_info[0]["name"]
+    game_name = ''
+    try:
+        stream = client.get_streams(user_logins = channel)._queue[0]
+        game_id = stream["game_id"]
+        game_info = client.get_games(game_ids=game_id)
+        game_name = game_info[0]["name"]
+    except Exception as E:
+        print('Game info not available')
     return game_name


### PR DESCRIPTION
!addquote command would break if API call to get game info fails for any reason (API down, streamer offline, etc). Added a Try block around the api call. Now util.getGameName will return an empty string if it fails to pull the game info. This allows quotes to still be added, just missing the game info.